### PR TITLE
Update du docker-compose.yml -> alertmanager URI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - prometheus-data:/prometheus
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-      - ./alertmanager/alert.rules/alerts.rules.yml:/alertmanager/alert.rules/alerts.rules.yml
+      - ./alertmanager/alert.rules/alerts.rules.yml:/etc/alertmanager/alert.rules/alerts.rules.yml
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'


### PR DESCRIPTION
Test pour voir si c'est bien le /etc/ qui manquait et qui faisait échouer le build de prometheus et alertmanager